### PR TITLE
Don't show melee targeting gizmo for pawns not controlled by the player

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompMeleeTargettingGizmo.cs
@@ -169,6 +169,12 @@ namespace CombatExtended
         #region Methods
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
+            // Don't let people control melee targeting for non-colonist pawns or colonists in a mental state
+            if (!PawnParent.IsColonist || PawnParent.InAggroMentalState)
+            {
+                yield break;
+            }
+
             if (SkillReqA)
             {
                 yield return new Command_Action


### PR DESCRIPTION
Don't display the melee targeting gizmo for pawns that are not colonists or are otherwise not under the player's control (e.g. are in an aggressive mental state).

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
